### PR TITLE
Add markdown export

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -482,7 +482,7 @@ valid-metaclass-classmethod-first-arg=mcs
 max-args=8
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=10
 
 # Maximum number of boolean expressions in a if statement
 max-bool-expr=5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
       + Inclusive/exclusive labels
       + WIP/non-WIPed open merge requests
       + Aging merge requests
+    - Export to CSV or markdown
 
 
 [Unreleased]: https://github.com/hg-jt/mrnag

--- a/mrnag/__init__.py
+++ b/mrnag/__init__.py
@@ -152,7 +152,8 @@ class Gitlab(Forge):
 
         return project
 
-    def timestamp_to_datetime(self, timestamp) -> Optional[datetime]:
+    @staticmethod
+    def timestamp_to_datetime(timestamp) -> Optional[datetime]:
         """Convert a timestamp string to a datetime object with timezone info.
 
         GitLab's API uses timestamp strings in the format: %Y-%m-%dT%H:%M:%S.%fZ.


### PR DESCRIPTION
This MR adds basic markdown export.

To export Mr. Nag's output to markdown, use the `--to-format` (or the shorter `-t`) option with a value of `md`. For example: `mrnag -c config.yml -t md`